### PR TITLE
Topic/533 parser error

### DIFF
--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -515,6 +515,14 @@ object Parsers {
       if (in.token == DOT) { in.nextToken(); selectors(t, finish) }
       else t
 
+    /** SomeDotSelectors ::=  `.' Ident { `.' Ident
+     *
+     *  Accept some (at least one) `.' separated identifiers acting as a selectors on given tree `t`.
+     *  @param finish   An alternative parse in case the token following a `.' is not an identifier.
+     *                  If the alternative does not apply, its tree argument is returned unchanged.
+     */
+    def someDotSelectors(t: Tree, finish: Tree => Tree) = { accept(DOT); selectors(t, finish) }
+
     private val id: Tree => Tree = x => x
 
     /** Path       ::= StableId
@@ -553,18 +561,6 @@ object Parsers {
         }
         else t
       }
-    }
-
-
-    /** PathRest ::=  `.' Ident { `.' Ident }
-      *
-      *  Accept some (at least one) `.' separated identifiers acting as a selectors on given tree `t`.
-      *  @param finish   An alternative parse in case the token following a `.' is not an identifier.
-      *                  If the alternative does not apply, its tree argument is returned unchanged.
-      */
-    def someDotSelectors(t: Tree, finish: Tree => Tree) = {
-      accept(DOT)
-      selectors(t, finish)
     }
 
     /** MixinQualifier ::= `[' Id `]'

--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -494,7 +494,7 @@ object Parsers {
     def selector(t: Tree): Tree =
       atPos(t.pos.start, in.offset) { Select(t, ident()) }
 
-    /** Selectors ::= ident { `.' ident()
+    /** Selectors ::= Ident { `.' Ident }
      *
      *  Accept `.' separated identifiers acting as a selectors on given tree `t`.
      *  @param finish   An alternative parse in case the next token is not an identifier.

--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -555,6 +555,18 @@ object Parsers {
       }
     }
 
+
+    /** PathRest ::=  `.' Ident { `.' Ident }
+      *
+      *  Accept some (at least one) `.' separated identifiers acting as a selectors on given tree `t`.
+      *  @param finish   An alternative parse in case the token following a `.' is not an identifier.
+      *                  If the alternative does not apply, its tree argument is returned unchanged.
+      */
+    def someDotSelectors(t: Tree, finish: Tree => Tree) = {
+      accept(DOT)
+      selectors(t, finish)
+    }
+
     /** MixinQualifier ::= `[' Id `]'
     */
     def mixinQualifierOpt(): TypeName =

--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -505,7 +505,7 @@ object Parsers {
       if (t1 ne t) t1 else dotSelectors(selector(t), finish)
     }
 
-    /** Dotelectors ::= { `.' ident()
+    /** DotSelectors ::= { `.' Ident }
      *
      *  Accept `.' separated identifiers acting as a selectors on given tree `t`.
      *  @param finish   An alternative parse in case the token following a `.' is not an identifier.

--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -515,7 +515,7 @@ object Parsers {
       if (in.token == DOT) { in.nextToken(); selectors(t, finish) }
       else t
 
-    /** SomeDotSelectors ::=  `.' Ident { `.' Ident
+    /** SomeDotSelectors ::=  `.' Ident { `.' Ident }
      *
      *  Accept some (at least one) `.' separated identifiers acting as a selectors on given tree `t`.
      *  @param finish   An alternative parse in case the token following a `.' is not an identifier.

--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -536,35 +536,35 @@ object Parsers {
      */
     def path(thisOK: Boolean, finish: Tree => Tree = id): Tree = {
       val start = in.offset
-      var tTpeName: TypeName = tpnme.EMPTY
 
-      def acceptThis(): Tree = {
+      def acceptThis(name: TypeName): Tree = {
         in.nextToken()
-        atPos(start) { This(tTpeName) }
+        atPos(start) { This(name) }
       }
-      def acceptSuper(): Tree = {
+      def acceptSuper(name: TypeName): Tree = {
         in.nextToken()
         val mix = mixinQualifierOpt()
-        atPos(start) { Super(This(tTpeName), mix) }
+        atPos(start) { Super(This(name), mix) }
       }
-      def thisSuperOrElse(alternative: => Tree): Tree =
+      def thisSuperOrElse(name: TypeName)(alternative: => Tree): Tree =
         if (in.token == THIS && !thisOK)
-          someDotSelectors(acceptThis(), finish)
+          someDotSelectors(acceptThis(name), finish)
         else if (in.token == THIS)
-          manyDotSelectors(acceptThis(), finish)
+          manyDotSelectors(acceptThis(name), finish)
         else if (in.token == SUPER)
-          someDotSelectors(acceptSuper(), finish)
+          someDotSelectors(acceptSuper(name), finish)
         else
           alternative
 
       // `this' or `super' occur as first component of the path
-      thisSuperOrElse {
+      thisSuperOrElse(tpnme.EMPTY) {
         val t = termIdent()
         if (in.token == DOT) {
           in.nextToken()
-          tTpeName = t.name.toTypeName
           // `this' or `super' follow an identifier
-          thisSuperOrElse { selectors(t, finish) }
+          thisSuperOrElse(t.name.toTypeName) {
+            selectors(t, finish)
+          }
         } else {
           t
         }

--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -521,7 +521,7 @@ object Parsers {
      *              |  [Ident `.'] this
      *
      *  @param thisOK   If true, [Ident `.'] this is acceptable as the path.
-     *                  If false, another selection is required aftre the `this`.
+     *                  If false, another selection is required after the `this`.
      *  @param finish   An alternative parse in case the token following a `.' is not an identifier.
      *                  If the alternative does not apply, its tree argument is returned unchanged.
      */

--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -502,16 +502,16 @@ object Parsers {
      */
     def selectors(t: Tree, finish: Tree => Tree): Tree = {
       val t1 = finish(t)
-      if (t1 ne t) t1 else dotSelectors(selector(t), finish)
+      if (t1 ne t) t1 else manyDotSelectors(selector(t), finish)
     }
 
-    /** DotSelectors ::= { `.' Ident }
+    /** ManyDotSelectors ::= { `.' Ident }
      *
      *  Accept `.' separated identifiers acting as a selectors on given tree `t`.
      *  @param finish   An alternative parse in case the token following a `.' is not an identifier.
      *                  If the alternative does not apply, its tree argument is returned unchanged.
      */
-     def dotSelectors(t: Tree, finish: Tree => Tree = id) =
+     def manyDotSelectors(t: Tree, finish: Tree => Tree = id) =
       if (in.token == DOT) { in.nextToken(); selectors(t, finish) }
       else t
 
@@ -540,14 +540,14 @@ object Parsers {
         in.nextToken()
         val t = atPos(start) { This(name) }
         if (!thisOK && in.token != DOT) syntaxError("`.' expected")
-        dotSelectors(t, finish)
+        manyDotSelectors(t, finish)
       }
       def handleSuper(name: TypeName) = {
         in.nextToken()
         val mix = mixinQualifierOpt()
         val t = atPos(start) { Super(This(name), mix) }
         accept(DOT)
-        dotSelectors(selector(t), finish)
+        manyDotSelectors(selector(t), finish)
       }
       if (in.token == THIS) handleThis(tpnme.EMPTY)
       else if (in.token == SUPER) handleSuper(tpnme.EMPTY)
@@ -579,7 +579,7 @@ object Parsers {
     /** QualId ::= Id {`.' Id}
     */
     def qualId(): Tree =
-      dotSelectors(termIdent())
+      manyDotSelectors(termIdent())
 
     /** SimpleExpr    ::= literal
      *                  | symbol
@@ -1439,7 +1439,7 @@ object Parsers {
       case LPAREN =>
         atPos(in.offset) { makeTupleOrParens(inParens(patternsOpt())) }
       case LBRACE =>
-        dotSelectors(blockExpr())
+        manyDotSelectors(blockExpr())
       case XMLSTART =>
         xmlLiteralPattern()
       case _ =>

--- a/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -519,6 +519,7 @@ object Parsers {
 
     /** Path       ::= StableId
      *              |  [Ident `.'] this
+     *              |  [Ident `.'] super [ `[' Id `]' ]
      *
      *  @param thisOK   If true, [Ident `.'] this is acceptable as the path.
      *                  If false, another selection is required after the `this`.


### PR DESCRIPTION
Addresses #1589 (Parsers.scala:533) by rewriting the method `path` to remove the call to `syntaxError`. This does not improve the error messages per se. However, the cases for `this` and `super` are now handled a bit more uniformly.

Details:
- Fixes some typos in comments
- Updates some grammars in comments with missing productions
- Renames `dotSelectors` to `manyDotSelectors` and introduces corresponding `someDotSelectors`
- Refactors `path` to handle `this` and `super` more uniformly.