### PR TITLE
Add monadic val

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -870,9 +870,13 @@ object desugar {
    */
   def makeBind(stats: List[Tree], expr: Tree)(implicit ctx: Context): (List[Tree], Tree) = {
 
-    def makeLambda(name: TermName,  tpt: Tree, body: Tree): Tree = {
-      val param = ValDef(name, tpt, EmptyTree).withMods(Modifiers(Param))
-      Function(param :: Nil, body)
+    def makeLambda(pat: Tree,  tpt: Tree, body: Tree): Tree = pat match {
+      case id @ Ident(name: TermName) =>
+        val param = ValDef(name, tpt, EmptyTree).withMods(Modifiers(Param))
+        Function(param :: Nil, body)
+      // TODO add tpt here?
+      case _ =>
+        makeCaseLambda(CaseDef(pat, EmptyTree, body) :: Nil)
     }
 
     stats.foldRight[(List[Tree], Tree)]((Nil, expr)) {

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -875,16 +875,12 @@ object desugar {
       Function(param :: Nil, body)
     }
 
-    stats match {
-      case Nil => (Nil, expr)
-      case BindDef(name, tpt, rhs) :: rest => makeBind(rest, expr) match {
-        case (stats, expr) =>
-          val body = Block(stats, expr)
-          (Nil, Apply(Select(rhs, nme.flatMap), makeLambda(name, tpt, body)))
-      }
-      case otherDef :: rest => makeBind(rest, expr) match {
-        case (stats, expr) => (otherDef :: stats, expr)
-      }
+    stats.foldRight[(List[Tree], Tree)]((Nil, expr)) {
+      case (BindDef(name, tpt, rhs), (stats, expr)) =>
+        val body = Block(stats, expr)
+        (Nil, Apply(Select(rhs, nme.flatMap), makeLambda(name, tpt, body)))
+      case (other, (stats, expr)) =>
+        (other :: stats, expr)
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -91,6 +91,9 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   case class PatDef(mods: Modifiers, pats: List[Tree], tpt: Tree, rhs: Tree) extends DefTree
   case class DependentTypeTree(tp: List[Symbol] => Type) extends Tree
 
+  // Tree for monadic bind in blocks
+  case class BindDef(name: TermName, tpt: Tree, rhs: Tree) extends TermTree
+
   @sharable object EmptyTypeIdent extends Ident(tpnme.EMPTY) with WithoutTypeOrPos[Untyped] {
     override def isEmpty: Boolean = true
   }

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -92,7 +92,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   case class DependentTypeTree(tp: List[Symbol] => Type) extends Tree
 
   // Tree for monadic bind in blocks
-  case class BindDef(pat: Tree, tpt: Tree, rhs: Tree) extends TermTree
+  case class BindDef(mods: Modifiers, pat: Tree, tpt: Tree, rhs: Tree) extends TermTree
 
   @sharable object EmptyTypeIdent extends Ident(tpnme.EMPTY) with WithoutTypeOrPos[Untyped] {
     override def isEmpty: Boolean = true

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -92,7 +92,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   case class DependentTypeTree(tp: List[Symbol] => Type) extends Tree
 
   // Tree for monadic bind in blocks
-  case class BindDef(name: TermName, tpt: Tree, rhs: Tree) extends TermTree
+  case class BindDef(pat: Tree, tpt: Tree, rhs: Tree) extends TermTree
 
   @sharable object EmptyTypeIdent extends Ident(tpnme.EMPTY) with WithoutTypeOrPos[Untyped] {
     override def isEmpty: Boolean = true

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2195,10 +2195,11 @@ object Parsers {
           }
         } else EmptyTree
       lhs match {
-        case (id @ Ident(name: TermName)) :: Nil if isBind =>
-          BindDef(name, tpt, rhs)
+        case pat :: Nil if isBind =>
+          BindDef(pat, tpt, rhs)
         case (id @ Ident(name: TermName)) :: Nil =>
           ValDef(name, tpt, rhs).withMods(mods).setComment(in.getDocComment(start))
+        case _ if isBind => ???
         case _ =>
           PatDef(mods, lhs, tpt, rhs)
       }

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2182,8 +2182,8 @@ object Parsers {
       val rhs =
         if (isBind) {
           accept(LARROW)
-          // TODO support implicit
-          assert(!(mods is (Mutable | Lazy | Implicit)))
+          // TODO add better error messages
+          assert(!(mods is (Mutable | Lazy)))
           expr()
         } else if (tpt.isEmpty || in.token == EQUALS) {
           accept(EQUALS)
@@ -2196,7 +2196,7 @@ object Parsers {
         } else EmptyTree
       lhs match {
         case pat :: Nil if isBind =>
-          BindDef(pat, tpt, rhs)
+          BindDef(mods, pat, tpt, rhs)
         case (id @ Ident(name: TermName)) :: Nil =>
           ValDef(name, tpt, rhs).withMods(mods).setComment(in.getDocComment(start))
         case _ if isBind => ???


### PR DESCRIPTION
WIP

Adding monadic value bindings to block syntax. That is,

```scala
{
  val a <- ma
  val b <- mb
  foo(a, b)
}
```

desugars to:
```scala
{
  ma.flatMap { a => 
  mb.flatMap { b => 
    foo(a, b)
  }}
}
```

More details can be found in the [contributors forum](https://contributors.scala-lang.org/t/making-for-simpler-and-more-regular/2160/46?u=b-studios).